### PR TITLE
Allow ak2 API Keys

### DIFF
--- a/internal/validation/karakeep.go
+++ b/internal/validation/karakeep.go
@@ -11,7 +11,7 @@ import (
 func ValidateKarakeepToken(token secret.String) error {
 	// Define the pattern for a valid Karakeep API Key
 	// See: https://github.com/karakeep-app/karakeep/blob/v0.20.0/packages/trpc/auth.ts#L14
-	pattern := `^ak[12]_[a-f0-9]{20}_[a-f0-9]{20}$`
+	pattern := `^ak1_[a-f0-9]{20}_[a-f0-9]{20}$|^ak2_[a-f0-9]{20}_[a-f0-9]{32}$`
 	re := regexp.MustCompile(pattern)
 
 	// Check if the token matches the defined pattern

--- a/internal/validation/karakeep.go
+++ b/internal/validation/karakeep.go
@@ -11,7 +11,7 @@ import (
 func ValidateKarakeepToken(token secret.String) error {
 	// Define the pattern for a valid Karakeep API Key
 	// See: https://github.com/karakeep-app/karakeep/blob/v0.20.0/packages/trpc/auth.ts#L14
-	pattern := `^ak1_[a-f0-9]{20}_[a-f0-9]{20}$`
+	pattern := `^ak[12]_[a-f0-9]{20}_[a-f0-9]{20}$`
 	re := regexp.MustCompile(pattern)
 
 	// Check if the token matches the defined pattern

--- a/internal/validation/karakeep_test.go
+++ b/internal/validation/karakeep_test.go
@@ -12,10 +12,11 @@ func TestValidateKarakeepToken(t *testing.T) {
 		token    secret.String
 		expected bool
 	}{
-		{secret.New("ak1_1fa4507e4b58b5850672_13cb03dc5372fbe200d5"), true},           // Valid token
-		{secret.New("ak1_cc2109516bfc2282a2bb_d7ad539acb2401b3f4b8"), true},           // Valid token
-		{secret.New("ak2_628336a9531f92a42f55_08835688ea5708f0b83b"), true},           // Valid token
-		{secret.New("ak3_628336a9531f92a42f55_08835688ea5708f0b83b"), true},         // Invalid prefix
+		{secret.New("ak1_1fa4507e4b58b5850672_13cb03dc5372fbe200d5"), true},             // Valid token
+		{secret.New("ak1_cc2109516bfc2282a2bb_d7ad539acb2401b3f4b8"), true},             // Valid token
+		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337c68fd93a672e"), true}, // Valid token
+		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337"), true},             // Invalid token length
+		{secret.New("ak3_628336a9531f92a42f55_08835688ea5708f0b83b"), false},            // Invalid prefix
 		{secret.New("ak1_12345_67890"), false},                                        // Invalid format (too short)
 		{secret.New("ak1_4d22ace06b233b9d2d22_c96e719"), false},                       // Invalid (too short for second segment)
 		{secret.New("ak1_eca9dd7db9a4d7585f61b3063337d_054ef423745a72c0a7a8"), false}, // Invalid (too long for first segment)

--- a/internal/validation/karakeep_test.go
+++ b/internal/validation/karakeep_test.go
@@ -14,7 +14,8 @@ func TestValidateKarakeepToken(t *testing.T) {
 	}{
 		{secret.New("ak1_1fa4507e4b58b5850672_13cb03dc5372fbe200d5"), true},           // Valid token
 		{secret.New("ak1_cc2109516bfc2282a2bb_d7ad539acb2401b3f4b8"), true},           // Valid token
-		{secret.New("ak2_628336a9531f92a42f55_08835688ea5708f0b83b"), false},          // Invalid prefix
+		{secret.New("ak2_628336a9531f92a42f55_08835688ea5708f0b83b"), true},           // Valid token
+		{secret.New("ak3_628336a9531f92a42f55_08835688ea5708f0b83b"), true},         // Invalid prefix
 		{secret.New("ak1_12345_67890"), false},                                        // Invalid format (too short)
 		{secret.New("ak1_4d22ace06b233b9d2d22_c96e719"), false},                       // Invalid (too short for second segment)
 		{secret.New("ak1_eca9dd7db9a4d7585f61b3063337d_054ef423745a72c0a7a8"), false}, // Invalid (too long for first segment)

--- a/internal/validation/karakeep_test.go
+++ b/internal/validation/karakeep_test.go
@@ -15,9 +15,8 @@ func TestValidateKarakeepToken(t *testing.T) {
 		{secret.New("ak1_1fa4507e4b58b5850672_13cb03dc5372fbe200d5"), true},             // Valid token
 		{secret.New("ak1_cc2109516bfc2282a2bb_d7ad539acb2401b3f4b8"), true},             // Valid token
 		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337c68fd93a672e"), true}, // Valid token
-		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337"), true},             // Invalid token length
+		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337"), false},            // Invalid token length
 		{secret.New("ak3_628336a9531f92a42f55_08835688ea5708f0b83b"), false},            // Invalid prefix
->>
 		{secret.New("ak1_12345_67890"), false},                                          // Invalid format (too short)
 		{secret.New("ak1_4d22ace06b233b9d2d22_c96e719"), false},                         // Invalid (too short for second segment)
 		{secret.New("ak1_eca9dd7db9a4d7585f61b3063337d_054ef423745a72c0a7a8"), false},   // Invalid (too long for first segment)

--- a/internal/validation/karakeep_test.go
+++ b/internal/validation/karakeep_test.go
@@ -17,10 +17,11 @@ func TestValidateKarakeepToken(t *testing.T) {
 		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337c68fd93a672e"), true}, // Valid token
 		{secret.New("ak2_1495f2286c3b9ce53369_c01b55fbfe220e010337"), true},             // Invalid token length
 		{secret.New("ak3_628336a9531f92a42f55_08835688ea5708f0b83b"), false},            // Invalid prefix
-		{secret.New("ak1_12345_67890"), false},                                        // Invalid format (too short)
-		{secret.New("ak1_4d22ace06b233b9d2d22_c96e719"), false},                       // Invalid (too short for second segment)
-		{secret.New("ak1_eca9dd7db9a4d7585f61b3063337d_054ef423745a72c0a7a8"), false}, // Invalid (too long for first segment)
-		{secret.New("invalidtoken"), false},                                           // Completely invalid
+>>
+		{secret.New("ak1_12345_67890"), false},                                          // Invalid format (too short)
+		{secret.New("ak1_4d22ace06b233b9d2d22_c96e719"), false},                         // Invalid (too short for second segment)
+		{secret.New("ak1_eca9dd7db9a4d7585f61b3063337d_054ef423745a72c0a7a8"), false},   // Invalid (too long for first segment)
+		{secret.New("invalidtoken"), false},                                             // Completely invalid
 	}
 
 	// Iterate over the test cases

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -7,7 +7,7 @@
 //
 //   - ValidateKarakeepToken: Validates the format of the Karakeep API Key,
 //     ensuring it follows the expected pattern of `ak1_{20_hex_characters}_{20_hex_characters}`.
-//     or the newer `ak2_{20_hex_characters}_{20_hex_characters}`.
+//     or the newer `ak2_{20_hex_characters}_{32_hex_characters}`.
 //
 //   - ValidateTelegramToken: Validates the format of a Telegram bot token,
 //     ensuring it matches the required pattern of `8-10 digits:followed by a 35-character string`.

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -7,6 +7,7 @@
 //
 //   - ValidateKarakeepToken: Validates the format of the Karakeep API Key,
 //     ensuring it follows the expected pattern of `ak1_{20_hex_characters}_{20_hex_characters}`.
+//     or the newer `ak2_{20_hex_characters}_{20_hex_characters}`.
 //
 //   - ValidateTelegramToken: Validates the format of a Telegram bot token,
 //     ensuring it matches the required pattern of `8-10 digits:followed by a 35-character string`.


### PR DESCRIPTION
Maybe this is by design and I shouldn't be allowed to but I cannot create an `ak1` prefixed API key it only creates `ak2` API keys.

Hopefully this change allows both