### PR TITLE
feat: add SOCKS5 and HTTP proxy support for Telegram client

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ Additionally, you can override the configuration values using environment variab
 KARAKEEPBOT_LOGGING_LEVEL=debug KARAKEEPBOT_TELEGRAM_ALLOWLIST=chat_id_1,chat_id_2 karakeepbot
 ```
 
+### Proxy Configuration
+
+If you need to connect through a proxy (e.g., SOCKS5), enable it in your config:
+
+```toml
+[telegram]
+proxyenabled = true
+proxyurl = "socks5://127.0.0.1:1080"
+```
+
+Or via environment variables:
+
+```sh
+KARAKEEPBOT_TELEGRAM_PROXYENABLED=true \
+KARAKEEPBOT_TELEGRAM_PROXYURL=socks5://127.0.0.1:1080 \
+karakeepbot
+```
+
+Supported schemes: `socks5://`, `http://`, `https://`.
+
 ### Security Concerns
 
 To protect your bot from abuse and spam from unauthorized users, `Karakeepbot` implements a **mandatory Chat ID allowlist**.

--- a/config.default.toml
+++ b/config.default.toml
@@ -18,6 +18,12 @@ allowlist = [-1]
 # (default), the bot will interact with all threads.
 threads = []
 
+# Whether to use a proxy for Telegram Bot API connections.
+proxyenabled = false
+
+# Proxy URL (e.g., "socks5://127.0.0.1:1080" or "http://proxy.example.com:8080").
+# proxyurl = "socks5://127.0.0.1:1080"
+
 # ------------------------------------------
 # Karakeep configuration
 # ------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,8 +72,10 @@ var DefaultPath = filepath.Join(os.Getenv("KO_DATA_PATH"), DefaultConfigFile)
 // DefaultConfig is the default configuration for the bot.
 var DefaultConfig = Config{
 	Telegram: TelegramConfig{
-		Allowlist: []int64{-1}, // Enforce allowlist by default.
-		Threads:   []int(nil),
+		Allowlist:    []int64{-1}, // Enforce allowlist by default.
+		Threads:      []int(nil),
+		ProxyEnabled: false,
+		ProxyURL:     "",
 	},
 	Karakeep: KarakeepConfig{
 		URL:      "http://localhost:3000",

--- a/internal/config/telegram.go
+++ b/internal/config/telegram.go
@@ -9,9 +9,11 @@ import (
 
 // TelegramConfig represents a configuration for Telegram.
 type TelegramConfig struct {
-	Token     secret.String `koanf:"token"`     // Telegram bot token.
-	Allowlist []int64       `koanf:"allowlist"` // Allowed chat IDs for the bot to interact with.
-	Threads   []int         `koanf:"threads"`   // Allowed thread IDs (a.k.a topics) for the bot to interact with.
+	Token        secret.String `koanf:"token"`        // Telegram bot token.
+	Allowlist    []int64       `koanf:"allowlist"`    // Allowed chat IDs for the bot to interact with.
+	Threads      []int         `koanf:"threads"`      // Allowed thread IDs (a.k.a topics) for the bot to interact with.
+	ProxyEnabled bool          `koanf:"proxyenabled"` // Whether to use a proxy for Telegram Bot API connections.
+	ProxyURL     string        `koanf:"proxyurl"`     // Proxy URL (e.g., "socks5://127.0.0.1:1080").
 }
 
 // Validate checks if the Telegram configuration is valid.
@@ -22,6 +24,10 @@ func (c TelegramConfig) Validate() error {
 
 	if len(c.Allowlist) == 1 && c.Allowlist[0] == -1 {
 		return fmt.Errorf("invalid Telegram Allowlist (-1). Please configure it with your actual chat ID or an empty list to allow all users (not recommended)")
+	}
+
+	if c.ProxyEnabled && c.ProxyURL == "" {
+		return fmt.Errorf("proxyurl must be set when proxyenabled is true")
 	}
 
 	return nil

--- a/internal/fileprocessor/fileprocessor.go
+++ b/internal/fileprocessor/fileprocessor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -27,13 +28,17 @@ type Validator func(file *os.File) (contentType string, err error)
 
 // Processor is responsible for downloading and processing files.
 type Processor struct {
-	tempdir string
-	maxsize int64
-	timeout int
+	tempdir      string
+	maxsize      int64
+	timeout      int
+	proxyEnabled bool
+	proxyURL     string
 }
 
 // New creates a new Processor using the provided configuration.
-func New(config *config.FileProcessorConfig) (*Processor, error) {
+// If proxyEnabled is true, the HTTP client used for downloads will route
+// through the specified proxyURL.
+func New(config *config.FileProcessorConfig, proxyEnabled bool, proxyURL string) (*Processor, error) {
 	// Create a temporary directory for storing files.
 	tempdir := config.Tempdir
 	if tempdir == "" {
@@ -44,9 +49,11 @@ func New(config *config.FileProcessorConfig) (*Processor, error) {
 	}
 
 	return &Processor{
-		tempdir: tempdir,
-		maxsize: config.Maxsize,
-		timeout: config.Timeout,
+		tempdir:      tempdir,
+		maxsize:      config.Maxsize,
+		timeout:      config.Timeout,
+		proxyEnabled: proxyEnabled,
+		proxyURL:     proxyURL,
 	}, nil
 }
 
@@ -71,9 +78,18 @@ func (p *Processor) Process(fileURL string, validator Validator) (path string, c
 		}
 	}()
 
-	// Configure an HTTP client with the specified timeout.
+	// Configure an HTTP client with the specified timeout and optional proxy.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if p.proxyEnabled && p.proxyURL != "" {
+		proxyURL, err := url.Parse(p.proxyURL)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse proxy URL: %w", err)
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
 	client := http.Client{
-		Timeout: time.Duration(p.timeout) * time.Second,
+		Transport: transport,
+		Timeout:   time.Duration(p.timeout) * time.Second,
 	}
 
 	// Download the file.

--- a/internal/fileprocessor/fileprocessor_test.go
+++ b/internal/fileprocessor/fileprocessor_test.go
@@ -46,6 +46,8 @@ func TestProcessor_Process(t *testing.T) {
 		config        config.FileProcessorConfig
 		urlPath       string
 		validator     Validator
+		proxyEnabled  bool
+		proxyURL      string
 		expectError   bool
 		expectedError error
 	}{
@@ -105,11 +107,21 @@ func TestProcessor_Process(t *testing.T) {
 			expectError:   true,
 			expectedError: ErrDownloadFailed,
 		},
+		{
+			name:          "Fail with proxy enabled and unreachable proxy",
+			config:        config.FileProcessorConfig{Maxsize: 100, Timeout: 5},
+			urlPath:       "/valid.png",
+			validator:     nil,
+			proxyEnabled:  true,
+			proxyURL:      "socks5://127.0.0.1:1",
+			expectError:   true,
+			expectedError: ErrDownloadFailed,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			processor, err := New(&tt.config)
+			processor, err := New(&tt.config, tt.proxyEnabled, tt.proxyURL)
 			if err != nil {
 				t.Fatalf("Failed to create processor: %v", err)
 			}

--- a/internal/karakeepbot/karakeepbot.go
+++ b/internal/karakeepbot/karakeepbot.go
@@ -39,7 +39,7 @@ type KarakeepBot struct {
 // clients.
 func New(logger *logging.Logger, config *config.Config) *KarakeepBot {
 	// Initialize FileProcessor
-	fileProcessor, err := fileprocessor.New(&config.FileProcessor)
+	fileProcessor, err := fileprocessor.New(&config.FileProcessor, config.Telegram.ProxyEnabled, config.Telegram.ProxyURL)
 	if err != nil {
 		logger.Fatal("Failed to create file processor", "error", err)
 	}

--- a/internal/karakeepbot/telegram.go
+++ b/internal/karakeepbot/telegram.go
@@ -3,6 +3,9 @@ package karakeepbot
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/Madh93/karakeepbot/internal/config"
 	"github.com/Madh93/karakeepbot/internal/logging"
@@ -24,7 +27,25 @@ type Telegram struct {
 func createTelegram(logger *logging.Logger, config *config.TelegramConfig) *Telegram {
 	logger.Debug(fmt.Sprintf("Initializing Telegram Bot API using %s token", config.Token))
 
-	telegramBot, err := tgbotapi.New(config.Token.Value())
+	var opts []tgbotapi.Option
+
+	if config.ProxyEnabled {
+		proxyURL, err := url.Parse(config.ProxyURL)
+		if err != nil {
+			logger.Fatal("Error parsing proxy URL.", "error", err)
+		}
+
+		transport := &http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+		}
+		client := &http.Client{
+			Transport: transport,
+		}
+		opts = append(opts, tgbotapi.WithHTTPClient(30*time.Second, client))
+		opts = append(opts, tgbotapi.WithCheckInitTimeout(30*time.Second))
+	}
+
+	telegramBot, err := tgbotapi.New(config.Token.Value(), opts...)
 	if err != nil {
 		logger.Fatal("Error creating Telegram Bot API.", "error", err)
 	}


### PR DESCRIPTION
Add proxyenabled and proxyurl configuration options to the Telegram config. When enabled, the Telegram bot client uses the configured SOCKS5 or HTTP proxy for all API connections.

Also applies the proxy configuration to file downloads (photo/images) via the file processor, which previously bypassed the proxy and caused timeouts in proxy-required environments.

Disabled by default to maintain backward compatibility.