### PR TITLE
feat: extract hashtags from messages and photo captions as bookmark tags

### DIFF
--- a/internal/karakeepbot/enricher.go
+++ b/internal/karakeepbot/enricher.go
@@ -3,9 +3,17 @@ package karakeepbot
 import "context"
 
 // enrichBookmark adds Telegram origin metadata to a newly created bookmark.
-// Currently attaches the #telegram tag. Non-fatal on failure.
+// It attaches the #telegram tag plus any hashtags found in the message text or
+// photo caption. Non-fatal on failure.
 func (kb *KarakeepBot) enrichBookmark(ctx context.Context, msg TelegramMessage, bookmark *KarakeepBookmark) {
-	if err := kb.karakeep.AddTag(ctx, bookmark.Id, "telegram"); err != nil {
-		kb.logger.Warn("Failed to add #telegram tag", "bookmark_id", bookmark.Id, "error", err)
+	tags := []string{"telegram"}
+	for _, tag := range msg.Hashtags() {
+		if tag != "telegram" {
+			tags = append(tags, tag)
+		}
+	}
+
+	if err := kb.karakeep.AddTags(ctx, bookmark.Id, tags); err != nil {
+		kb.logger.Warn("Failed to add tags", "bookmark_id", bookmark.Id, "tags", tags, "error", err)
 	}
 }

--- a/internal/karakeepbot/karakeep.go
+++ b/internal/karakeepbot/karakeep.go
@@ -1,7 +1,9 @@
 package karakeepbot
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -10,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/Madh93/go-karakeep"
 	"github.com/Madh93/karakeepbot/internal/config"
@@ -178,17 +179,33 @@ func (k Karakeep) CreateAsset(ctx context.Context, filePath string, mimeType str
 	return &asset, nil
 }
 
-// AddTag attaches a human-attached tag to an existing bookmark.
-func (k Karakeep) AddTag(ctx context.Context, bookmarkID string, tagName string) error {
-	payload := fmt.Sprintf(`{"tags":[{"tagName":"%s"}]}`, tagName)
-	body := strings.NewReader(payload)
+// AddTags attaches human-attached tags to an existing bookmark.
+func (k Karakeep) AddTags(ctx context.Context, bookmarkID string, tagNames []string) error {
+	if len(tagNames) == 0 {
+		return nil
+	}
 
-	response, err := k.PostBookmarksBookmarkIdTagsWithBodyWithResponse(ctx, bookmarkID, "application/json", body)
+	type tag struct {
+		TagName string `json:"tagName"`
+	}
+	payload := struct {
+		Tags []tag `json:"tags"`
+	}{}
+	for _, name := range tagNames {
+		payload.Tags = append(payload.Tags, tag{TagName: name})
+	}
+
+	data, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to add tag: %w", err)
+		return fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	response, err := k.PostBookmarksBookmarkIdTagsWithBodyWithResponse(ctx, bookmarkID, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("failed to add tags: %w", err)
 	}
 	if response.StatusCode() != http.StatusOK {
-		return fmt.Errorf("failed to add tag, received HTTP status: %s", response.Status())
+		return fmt.Errorf("failed to add tags, received HTTP status: %s", response.Status())
 	}
 
 	return nil

--- a/internal/karakeepbot/telegram_message.go
+++ b/internal/karakeepbot/telegram_message.go
@@ -2,11 +2,16 @@ package karakeepbot
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/go-telegram/bot/models"
 )
+
+// hashtagRegexp matches Telegram-style hashtags, capturing the tag name
+// without the leading '#'. Supports unicode letters and digits.
+var hashtagRegexp = regexp.MustCompile(`#([\p{L}\p{N}_]+)`)
 
 // TelegramUpdate is an alias for models.Update.
 type TelegramUpdate = models.Update
@@ -85,6 +90,23 @@ func (tm TelegramMessage) EntityURLs() []string {
 		}
 	}
 	return urls
+}
+
+// Hashtags returns the unique hashtags found in the message text and photo
+// caption, without the leading '#'.
+func (tm TelegramMessage) Hashtags() []string {
+	seen := make(map[string]struct{})
+	var tags []string
+	for _, source := range []string{tm.Text, tm.Caption} {
+		for _, match := range hashtagRegexp.FindAllStringSubmatch(source, -1) {
+			tag := match[1]
+			if _, ok := seen[tag]; !ok {
+				seen[tag] = struct{}{}
+				tags = append(tags, tag)
+			}
+		}
+	}
+	return tags
 }
 
 // authorInfo returns the origin type and display name for the message author.

--- a/internal/karakeepbot/telegram_message_test.go
+++ b/internal/karakeepbot/telegram_message_test.go
@@ -1,0 +1,62 @@
+package karakeepbot
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestHashtags(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		caption  string
+		expected []string
+	}{
+		{
+			name:     "no hashtags",
+			text:     "just some text",
+			expected: nil,
+		},
+		{
+			name:     "hashtags in text",
+			text:     "check this out #golang #programming",
+			expected: []string{"golang", "programming"},
+		},
+		{
+			name:     "hashtags in photo caption",
+			caption:  "sunset at the beach #travel #photography",
+			expected: []string{"travel", "photography"},
+		},
+		{
+			name:     "duplicate hashtags are deduplicated",
+			text:     "#golang stuff #golang",
+			caption:  "#golang",
+			expected: []string{"golang"},
+		},
+		{
+			name:     "unicode hashtags",
+			caption:  "#путешествия and #日本語",
+			expected: []string{"путешествия", "日本語"},
+		},
+		{
+			name:     "hashtag with underscore and digits",
+			text:     "#web_dev #tag123",
+			expected: []string{"web_dev", "tag123"},
+		},
+		{
+			name:     "hash without tag name is ignored",
+			text:     "# not a tag, nor is #",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := TelegramMessage{Text: tt.text, Caption: tt.caption}
+			got := msg.Hashtags()
+			if !slices.Equal(got, tt.expected) {
+				t.Errorf("Hashtags() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Hashtags written in a Telegram message text or photo caption are now attached to the created Karakeep bookmark as human tags, alongside the existing `#telegram` tag.

- `TelegramMessage.Hashtags()` extracts unique hashtags from both the message text and photo caption using a unicode-aware regex (e.g. `#путешествия`, `#日本語` work), returning names without the leading `#`.
- `enrichBookmark` attaches these hashtags together with the `#telegram` tag; since enrichment runs for every bookmark type, this covers photo, text, link, and forwarded-channel bookmarks uniformly.
- Replaced `AddTag` with `AddTags`: all tags are sent in a single API call, and the payload is built with `json.Marshal` instead of string formatting, so tag names with special characters can't break the JSON.

## Test plan

- [x] Added `telegram_message_test.go` covering hashtags in text, in captions, deduplication, unicode tags, underscores/digits, and bare `#` edge cases.
- [x] `go build ./...`, `go vet`, and `go test ./...` all pass.